### PR TITLE
fix: The top background color on the web page is causing the logo to not be displayed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,6 @@
     "github"
   ],
   "icon": "resources/images/logo.png",
-  "galleryBanner": {
-    "color": "#FF714C",
-    "theme": "dark"
-  },
   "engines": {
     "vscode": "^1.82.0"
   },


### PR DESCRIPTION
fix #1 