### PR TITLE
Failed to package by github action `HaaLeo/publish-vscode-extension`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,4 +32,3 @@ jobs:
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          dependencies: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,19 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
-## [0.0.5] 2024-10-15
+## [0.0.6] 2024-10-16
+
+### Fixed
+
+- Failed to package by github action `HaaLeo/publish-vscode-extension`.
+
+## ~~[0.0.5] 2024-10-15~~
 
 ### Fixed
 
 - Change package manager from `pnpm` to `npm`. (https://github.com/microsoft/vscode-vsce/issues/421#issuecomment-1853833167)
+
+**This version has been broken by `HaaLeo/publish-vscode-extension` action.**
 
 ## ~~[0.0.4] 2024-10-15~~
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "github-issue-blog",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "github-issue-blog",
-      "version": "0.0.4",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@octokit/rest": "^20.1.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "github-issue-blog",
   "displayName": "Github Issue Blog",
   "description": "A vscode plugin to create a blog with issue",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "author": "wtto00",
   "publisher": "wtto00",
   "license": "MIT",


### PR DESCRIPTION
In the previous version, the CI parameter `dependencies: false` was set using `pnpm`. After switching to `npm`, the packaged extension is not usable.